### PR TITLE
Allow nil send 2

### DIFF
--- a/MRChan/MRChan.m
+++ b/MRChan/MRChan.m
@@ -172,7 +172,7 @@
     {
         sem_wait(_sem_empty);
         sem_wait(_sem_protected_receive);
-        *object = _objects[_next];
+        if (object) *object = _objects[_next];
         _next = (_next+1)%_buff_sz;
         sem_signal(_sem_protected_receive);
         sem_signal(_sem_full);
@@ -181,7 +181,7 @@
     {
         sem_wait(_sem_protected_receive);
         sem_wait(_sem_sent);
-        *object = _objects[0];
+        if (object) *object = _objects[0];
         sem_signal(_sem_received);
         sem_signal(_sem_protected_receive);
     }
@@ -205,7 +205,7 @@
             return FALSE;
         }
         
-        *object = _objects[_next];
+        if (object) *object = _objects[_next];
         _next = (_next+1)%_buff_sz;
         
         sem_signal(_sem_protected_receive);
@@ -226,7 +226,7 @@
             return FALSE;
         }
         
-        *object = _objects[0];
+        if (object) *object = _objects[0];
         sem_signal(_sem_received);
         sem_signal(_sem_protected_receive);
     }

--- a/MRChanTests/MRChanTests.m
+++ b/MRChanTests/MRChanTests.m
@@ -43,6 +43,31 @@
     [super tearDown];
 }
 
+- (void)testNilSelectSend
+{
+    __block bool testPassed = false;
+    MRChan *chan = [[MRChan alloc] initWithSize:1];
+    SelectCase sendNil = [chan caseSend:nil block:nil];
+    SelectCase recNil = [chan caseReceive:^(NSObject *obj){
+        testPassed = nil == obj;
+    }];
+    [MRChan select:sendNil, recNil, nil];
+    [MRChan select:sendNil, recNil, nil];
+    XCTAssert(testPassed);
+}
+
+
+- (void)testNilSend
+{
+    MRChan *chan = [[MRChan alloc] initWithSize:1];
+    [chan send:nil];
+    NSString *something = @"I am a string, how are you?";
+    [chan receive:&something];
+    XCTAssert(something == nil);
+}
+
+
+
 - (void)testQuitChannel
 {
     __block BOOL quit = false;


### PR DESCRIPTION
Sending nil over channels now works just like in Golang.